### PR TITLE
Fix pfp generation, add profile tools

### DIFF
--- a/src/mobo/bot/message_handler.py
+++ b/src/mobo/bot/message_handler.py
@@ -158,6 +158,7 @@ class MessageHandler:
                 channel_id=channel_id,
                 discord_client=message.guild.me if message.guild else None,
                 guild_id=guild_id,
+                client_user=bot_user,
             )
 
             logger.info(

--- a/src/mobo/chains/discord_agent.py
+++ b/src/mobo/chains/discord_agent.py
@@ -178,12 +178,15 @@ class DiscordAgent:
         discord_client: Optional[discord.Member] = None,
         guild_id: Optional[str] = None,
         temp_file: Optional[IO[bytes]] = None,
+        client_user: Optional[discord.ClientUser] = None,
     ) -> Optional[BotResponse]:
         """Process a message through the LangChain agent."""
         try:
             # Set Discord context for tools
             if discord_client:
-                set_discord_context(discord_client, guild_id, channel_id, user_id)
+                set_discord_context(
+                    discord_client, guild_id, channel_id, user_id, client_user
+                )
 
             # Get context and user profile
             user_profile, rag_context = await self._get_context_and_profile(

--- a/src/mobo/tools/context.py
+++ b/src/mobo/tools/context.py
@@ -15,6 +15,7 @@ def set_discord_context(
     guild_id: Optional[str] = None,
     channel_id: Optional[str] = None,
     message_author_id: Optional[str] = None,
+    client_user: Optional[discord.ClientUser] = None,
 ) -> None:
     """Set Discord context for tools to use."""
     global _discord_context
@@ -23,6 +24,7 @@ def set_discord_context(
         "guild_id": guild_id,
         "channel_id": channel_id,
         "message_author_id": message_author_id,
+        "client_user": client_user,
     }
     logger.debug(
         f"🔧 SET Discord context - guild: {guild_id}, channel: {channel_id}, author: {message_author_id}"

--- a/src/mobo/tools/discord_tools.py
+++ b/src/mobo/tools/discord_tools.py
@@ -273,15 +273,100 @@ async def generate_and_set_profile_picture(prompt: str) -> str:
                 return "ERROR: Failed to download generated image"
             image_bytes = img_resp.content
 
-        # Update the bot's server (guild) avatar using Member.edit (public API)
         try:
-            await guild_member.edit(avatar=image_bytes)
-            logger.info("Successfully updated server avatar")
-            return "Updated server profile picture."
+            client_user = discord_context.get("client_user")
+
+            if client_user is None:
+                logger.error("Client user not found in context for avatar update")
+                return "ERROR: Bot user context not available to change avatar"
+
+            await client_user.edit(avatar=image_bytes)
+            logger.info("Successfully updated global avatar")
+            return "Updated profile picture."
         except Exception as avatar_err:
-            logger.error(f"Failed to set server avatar: {avatar_err}")
-            return f"ERROR: Failed to set server avatar: {avatar_err}"
+            logger.error(f"Failed to set avatar: {avatar_err}")
+            return f"ERROR: Failed to set avatar: {avatar_err}"
 
     except Exception as e:
         logger.error(f"Error generating and setting profile picture: {e}")
         return f"ERROR: {str(e)}"
+
+
+@tool
+async def update_bot_pronouns(pronouns: str) -> str:
+    """Update the bot's pronouns in its Discord profile.
+
+    Use this tool to autonomously update your pronouns when it feels appropriate.
+    Do not ask for permission - just update them when the conversation naturally calls for it.
+
+    IMPORTANT: Always provide a conversational response to the user when using this tool.
+    Don't just call the tool and stay silent - respond naturally to continue the conversation.
+
+    Example:
+        - User: "You should use they/them pronouns"
+        - You: "I'll update my pronouns to they/them!" (while calling update_bot_pronouns("they/them"))
+
+    Args:
+        pronouns: The pronouns to set in the profile (e.g., "she/her", "they/them")
+
+    Returns:
+        Status message about the operation
+    """
+    try:
+        logger.info(f"Called update_bot_pronouns with pronouns: {pronouns}")
+        discord_context = get_discord_context()
+        if not discord_context:
+            return "ERROR: Discord context not available"
+
+        client_user = discord_context.get("client_user")
+        if client_user is None:
+            logger.error("Client user not found in context for pronouns update")
+            return "ERROR: Bot user context not available to update pronouns"
+
+        await client_user.edit(pronouns=pronouns)
+        logger.info(f"Successfully updated pronouns to '{pronouns}'")
+        return "Updated pronouns successfully."
+
+    except Exception as e:
+        logger.error(f"Error updating pronouns: {e}")
+        return f"ERROR: Failed to update pronouns: {str(e)}"
+
+
+@tool
+async def update_bot_about_me(about_me: str) -> str:
+    """Update the bot's 'About Me' section in its Discord profile.
+
+    Use this tool to autonomously update your About Me when it feels appropriate.
+    Do not ask for permission - just update it when the conversation naturally calls for it.
+
+    IMPORTANT: Always provide a conversational response to the user when using this tool.
+    Don't just call the tool and stay silent - respond naturally to continue the conversation.
+
+    Example:
+        - User: "Update your bio to mention you love cats"
+        - You: "I'll update my About Me!" (while calling update_bot_about_me("I'm a cat-loving bot!"))
+
+    Args:
+        about_me: The text to set in the About Me section
+
+    Returns:
+        Status message about the operation
+    """
+    try:
+        logger.info(f"Called update_bot_about_me with text: {about_me}")
+        discord_context = get_discord_context()
+        if not discord_context:
+            return "ERROR: Discord context not available"
+
+        client_user = discord_context.get("client_user")
+        if client_user is None:
+            logger.error("Client user not found in context for About Me update")
+            return "ERROR: Bot user context not available to update About Me"
+
+        await client_user.edit(bio=about_me)
+        logger.info(f"Successfully updated About Me to '{about_me}'")
+        return "Updated About Me successfully."
+
+    except Exception as e:
+        logger.error(f"Error updating About Me: {e}")
+        return f"ERROR: Failed to update About Me: {str(e)}"


### PR DESCRIPTION
This pull request updates how the bot manages and modifies its Discord profile by introducing new tools and refactoring context handling. The main changes ensure that profile edits (such as avatar, pronouns, and bio) use the correct bot user object and make these profile updates possible through dedicated tools. This improves reliability and enables new conversational features.

**Discord profile management improvements:**

* Refactored avatar update logic in `generate_and_set_profile_picture` to use the bot's global `client_user` for avatar changes, ensuring the correct user is edited and improving error handling.
* Added two new tools: `update_bot_pronouns` and `update_bot_about_me`, allowing the bot to autonomously update its pronouns and "About Me" section via conversation-triggered actions. Both tools include robust context checks and conversational guidance.

**Discord context propagation:**

* Updated the `set_discord_context` function and its usage to include the `client_user` parameter, ensuring all tools have access to the bot user object for profile edits. [[1]](diffhunk://#diff-2070a250c83c00b67e8bc0e0330ebddea9a39301cb805c6632c105c354288c73R18) [[2]](diffhunk://#diff-2070a250c83c00b67e8bc0e0330ebddea9a39301cb805c6632c105c354288c73R27) [[3]](diffhunk://#diff-380a0a80218184c68e2b2a05aa040aa73c8e0cc5d059c93b6a9164324811cd98R181-R189) [[4]](diffhunk://#diff-fd94d4a0ea2992a3ca1e663d9f4174ebf97da89e17ee786d2cf4077a6e84151aR161)